### PR TITLE
Allow a wider range of temperatures

### DIFF
--- a/accessories/smartthings.js
+++ b/accessories/smartthings.js
@@ -328,6 +328,7 @@ function SmartThingsAccessory(platform, device) {
     if (device.capabilities["Temperature Measurement"] !== undefined) {
         if (this.deviceGroup == 'unknown') this.deviceGroup = "sensor";
         thisCharacteristic = this.getaddService(Service.TemperatureSensor).getCharacteristic(Characteristic.CurrentTemperature)
+        thisCharacteristic.setProps ({ minValue: -100, maxValue: 300 })
         thisCharacteristic.on('get', function(callback) {
                 if (that.platform.temperature_unit == 'C')
                     callback(null, Math.round(that.device.attributes.temperature*10)/10);


### PR DESCRIPTION
Currently temperatures below 32F aren't passed.  There must be a default min set in HomeBridge.