### PR TITLE
Fixes device commands with 0 valued parameters.

### DIFF
--- a/smartapps/pdlove/json-complete-api.src/json-complete-api.groovy
+++ b/smartapps/pdlove/json-complete-api.src/json-complete-api.groovy
@@ -200,9 +200,9 @@ def deviceCommand() {
       	def value1 = request.JSON?.value1
       	def value2 = request.JSON?.value2
       	try {
-      		if (value2) {
+      		if (value2!=null) {
 	       		device."$command"(value1,value2)
-	    	} else if (value1) {
+	    	} else if (value1!=null) {
 	    		device."$command"(value1)
 	    	} else {
 	    		device."$command"()


### PR DESCRIPTION
When sending device commands, explicitly compare parameter values to null. This
allows command parameters that would otherwise implicitly evaluate to false in
conditionals (e.g. 0 value integers.)

Prior to this change, for example, a 'setLevel(0)' command would be sent to the
device handler as 'setLevel()' and not all devices (e.g. window coverings) are
able to gracefully handle the elided parameter value.