### PR TITLE
Updating fan speed controllers to properly align HomeKit and SmartThings statuses

### DIFF
--- a/src/ST_DeviceCharacteristics.js
+++ b/src/ST_DeviceCharacteristics.js
@@ -266,7 +266,7 @@ module.exports = class DeviceCharacteristics {
             _accessory.getOrAddService(_service).removeCharacteristic(Characteristic.Active);
         }
         let spdSteps = 1;
-        if (_accessory.hasDeviceFlag('fan_3_spd')) spdSteps = 33;
+        if (_accessory.hasDeviceFlag('fan_3_spd')) spdSteps = 32;
         if (_accessory.hasDeviceFlag('fan_4_spd')) spdSteps = 25;
         let spdAttr = (_accessory.hasAttribute('level')) ? "level" : (_accessory.hasAttribute('fanSpeed') && _accessory.hasCommand('setFanSpeed')) ? 'fanSpeed' : undefined;
         if (_accessory.hasAttribute('level') || _accessory.hasAttribute('fanSpeed')) {

--- a/src/ST_Transforms.js
+++ b/src/ST_Transforms.js
@@ -468,9 +468,9 @@ module.exports = class Transforms {
     }
 
     fanSpeedLevelToInt(val) {
-        if (val > 0 && val < 33) {
+        if (val > 0 && val < 34) {
             return 1;
-        } else if (val >= 33 && val < 66) {
+        } else if (val >= 34 && val < 66) {
             return 2;
         } else if (val >= 66 && val <= 100) {
             return 3;


### PR DESCRIPTION
Minor updates to two files as discussed in https://github.com/tonesto7/homebridge-smartthings/issues/326 - HomeKit wasn't aligning Low/Medium/High to the SmartThings percentages for 3 speed fan DTH's properly.

Thanks to @jfsteele for the code suggestions, all credit to them for the fix here - I just hoped submitting a PR would accelerate getting this fixed.